### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,129 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/


### PR DESCRIPTION
To avoid unwanted files that are automatically generated by python, such as the "PyCache" cache, it is a good idea to **add a .gitignore file**, which **provides GitHub** in most default languages, including Python. You can learn more about .gitignore files [here](https://www.lifewire.com/gitignore-file-4153363#:~:text=A%20GITIGNORE%20file%20is%20a%20Git%20Ignore%20file.,as%20how%20to%20convert%20to%20the%20GITIGNORE%20format.)

Finally, I would like to add that if the application is advanced enough to be available, it would be a good idea to create a file with a _.exe_ extension so that people can test your application since to do so I have had to create a fork in GitHub and use it. With my python setup, something that either a lot of people don't want or are just lazy about. You can use PyInstaller to create the file using these commands:
`python -m pip install pyinstaller`
 To install pyinstaller and then:
 `pyinstaller --noconfirm --onefile --windowed --icon "Icon of the app" --name "Name of the app"  "Your file"
`

![image](https://user-images.githubusercontent.com/63709477/87788150-21920780-c83d-11ea-8c72-45565b852dfa.png)

I have also seen that you have a small _bug_ in the tag interface of your game. I  @PabloCorbCon would love to try to fix it. Get in touch with me if you need help with any other bug and I will be happy to help you.